### PR TITLE
[YOUQ-107] 외부 서비스에서 호출하는 유저 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/youquiz/user/domain/User.kt
+++ b/src/main/kotlin/com/youquiz/user/domain/User.kt
@@ -11,10 +11,10 @@ class User(
     @Id
     var id: Long? = null,
     val username: String,
-    var password: String,
-    var nickname: String,
+    val password: String,
+    val nickname: String,
     val role: Role,
-    var allowPush: Boolean,
+    val allowPush: Boolean,
 ) {
     @CreatedDate
     var createdDate: LocalDateTime = LocalDateTime.now()

--- a/src/main/kotlin/com/youquiz/user/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/com/youquiz/user/exception/UserNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.youquiz.user.exception
+
+import com.youquiz.user.global.exception.ServerException
+
+class UserNotFoundException(
+    override val message: String = "유저를 찾을 수 없습니다."
+) : ServerException(code = 404, message)

--- a/src/main/kotlin/com/youquiz/user/handler/UserHandler.kt
+++ b/src/main/kotlin/com/youquiz/user/handler/UserHandler.kt
@@ -16,4 +16,14 @@ class UserHandler(
         request.awaitBody<CreateUserRequest>().let {
             ServerResponse.ok().bodyValueAndAwait(userService.createUser(it))
         }
+
+    suspend fun findById(request: ServerRequest): ServerResponse =
+        request.pathVariable("id").let {
+            ServerResponse.ok().bodyValueAndAwait(userService.findById(it.toLong()))
+        }
+
+    suspend fun findByUsername(request: ServerRequest): ServerResponse =
+        request.pathVariable("username").let {
+            ServerResponse.ok().bodyValueAndAwait(userService.findByUsername(it))
+        }
 }

--- a/src/main/kotlin/com/youquiz/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/youquiz/user/repository/UserRepository.kt
@@ -7,4 +7,6 @@ import org.springframework.stereotype.Repository
 @Repository
 interface UserRepository : CoroutineCrudRepository<User, Long> {
     suspend fun findFirstByUsername(username: String): User?
+
+    suspend fun findByUsername(username: String): User?
 }

--- a/src/main/kotlin/com/youquiz/user/router/UserRouter.kt
+++ b/src/main/kotlin/com/youquiz/user/router/UserRouter.kt
@@ -13,6 +13,8 @@ class UserRouter {
     fun userRoutes(handler: UserHandler): RouterFunction<ServerResponse> =
         coRouter {
             "/user".nest {
+                GET("/{id}", handler::findById)
+                GET("/username/{username}", handler::findByUsername)
                 POST("", handler::createUser)
             }
         }

--- a/src/main/kotlin/com/youquiz/user/service/UserService.kt
+++ b/src/main/kotlin/com/youquiz/user/service/UserService.kt
@@ -4,6 +4,7 @@ import com.youquiz.user.domain.User
 import com.youquiz.user.domain.enum.Role
 import com.youquiz.user.dto.CreateUserRequest
 import com.youquiz.user.dto.UserResponse
+import com.youquiz.user.exception.UserNotFoundException
 import com.youquiz.user.exception.UsernameAlreadyExistException
 import com.youquiz.user.repository.UserRepository
 import org.springframework.security.crypto.password.PasswordEncoder
@@ -28,4 +29,10 @@ class UserService(
                 )
             ).let { UserResponse(it) }
         }
+
+    suspend fun findById(id: Long): UserResponse =
+        userRepository.findById(id)?.let { UserResponse(it) } ?: throw UserNotFoundException()
+
+    suspend fun findByUsername(username: String): UserResponse =
+        userRepository.findByUsername(username)?.let { UserResponse(it) } ?: throw UserNotFoundException()
 }

--- a/src/test/kotlin/com/youquiz/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/youquiz/user/controller/UserControllerTest.kt
@@ -5,6 +5,7 @@ import com.ninjasquad.springmockk.MockkBean
 import com.youquiz.user.config.SecurityTestConfiguration
 import com.youquiz.user.dto.CreateUserRequest
 import com.youquiz.user.dto.UserResponse
+import com.youquiz.user.exception.UserNotFoundException
 import com.youquiz.user.exception.UsernameAlreadyExistException
 import com.youquiz.user.fixture.*
 import com.youquiz.user.global.dto.ErrorResponse
@@ -14,11 +15,13 @@ import com.youquiz.user.service.UserService
 import com.youquiz.user.util.BaseControllerTest
 import com.youquiz.user.util.desc
 import com.youquiz.user.util.errorResponseFields
+import com.youquiz.user.util.paramDesc
 import io.mockk.coEvery
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.restdocs.operation.preprocess.Preprocessors
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.test.context.ContextConfiguration
 
 @ContextConfiguration(classes = [SecurityTestConfiguration::class])
@@ -56,6 +59,102 @@ class UserControllerTest : BaseControllerTest() {
     private val userResponsesFields = userResponseFields.map { "[].${it.path}" desc it.description as String }
 
     init {
+        describe("findById()는") {
+            context("존재하는 유저에 대한 식별자가 주어지면") {
+                coEvery { userService.findById(any()) } returns userResponse
+
+                it("상태 코드 200과 userResponse를 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/user/{id}", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(UserResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "식별자를 통한 유저 조회 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters("id" paramDesc "식별자"),
+                                responseFields(userResponseFields)
+                            )
+                        )
+                }
+            }
+
+            context("존재하지 않는 유저에 대한 식별자가 주어지면") {
+                coEvery { userService.findById(any()) } throws UserNotFoundException()
+
+                it("상태 코드 404와 에러를 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/user/{id}", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isNotFound
+                        .expectBody(ErrorResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "식별자를 통한 유저 조회 실패(404)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters("id" paramDesc "식별자"),
+                                responseFields(errorResponseFields)
+                            )
+                        )
+                }
+            }
+        }
+
+        describe("findByUsername()은") {
+            context("존재하는 유저에 대한 아이디가 주어지면") {
+                coEvery { userService.findByUsername(any()) } returns userResponse
+
+                it("상태 코드 200과 userResponse를 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/user/username/{username}", USERNAME)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(UserResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "아이디를 통한 유저 조회 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters("username" paramDesc "아이디"),
+                                responseFields(userResponseFields)
+                            )
+                        )
+                }
+            }
+
+            context("존재하지 않는 유저에 대한 아이디가 주어지면") {
+                coEvery { userService.findByUsername(any()) } throws UserNotFoundException()
+
+                it("상태 코드 404와 에러를 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/user/username/{username}", USERNAME)
+                        .exchange()
+                        .expectStatus()
+                        .isNotFound
+                        .expectBody(ErrorResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "아이디를 통한 유저 조회 실패(404)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters("username" paramDesc "아이디"),
+                                responseFields(errorResponseFields)
+                            )
+                        )
+                }
+            }
+        }
+
         describe("createUser()는") {
             context("존재하지 않는 아이디가 주어지면") {
                 coEvery { userService.createUser(any()) } returns userResponse

--- a/src/test/kotlin/com/youquiz/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/youquiz/user/service/UserServiceTest.kt
@@ -2,6 +2,7 @@ package com.youquiz.user.service
 
 import com.youquiz.user.dto.CreateUserRequest
 import com.youquiz.user.dto.UserResponse
+import com.youquiz.user.exception.UserNotFoundException
 import com.youquiz.user.exception.UsernameAlreadyExistException
 import com.youquiz.user.fixture.createUser
 import com.youquiz.user.repository.UserRepository
@@ -21,6 +22,52 @@ class UserServiceTest : BehaviorSpec() {
     )
 
     init {
+        Given("유저가 존재하는 경우") {
+            val user = createUser().also {
+                coEvery { userRepository.findById(any()) } returns it
+                coEvery { userRepository.findByUsername(any()) } returns it
+            }
+
+            When("식별자를 통해 유저 조회를 시도하면") {
+                val userResponse = userService.findById(user.id!!)
+
+                Then("식별자에 맞는 유저가 조회된다.") {
+                    userResponse shouldBeEqualToComparingFields UserResponse(user)
+                }
+            }
+
+            When("아이디를 통해 유저 조회를 시도하면") {
+                val userResponse = userService.findByUsername(user.username)
+
+                Then("아이디에 맞는 유저가 조회된다.") {
+                    userResponse shouldBeEqualToComparingFields UserResponse(user)
+                }
+            }
+        }
+
+        Given("유저가 존재하지 않는 경우") {
+            val user = createUser().also {
+                coEvery { userRepository.findById(any()) } returns null
+                coEvery { userRepository.findByUsername(any()) } returns null
+            }
+
+            When("식별자를 통해 유저 조회를 시도하면") {
+                Then("예외가 발생한다.") {
+                    shouldThrow<UserNotFoundException> {
+                        userService.findById(user.id!!)
+                    }
+                }
+            }
+
+            When("아이디를 통해 유저 조회를 시도하면") {
+                Then("예외가 발생한다.") {
+                    shouldThrow<UserNotFoundException> {
+                        userService.findByUsername(user.username)
+                    }
+                }
+            }
+        }
+
         Given("해당 아이디를 가진 유저가 없는 경우") {
             val newUser = createUser().also {
                 coEvery { userRepository.save(any()) } returns it


### PR DESCRIPTION
## 작업 내용

* **외부 서비스에서 호출되는 식별자 또는 아이디를 통한 유저 조회 기능 구현**

## 코멘트

* 코드 커버리지 패스를 위해 일시적으로 User 엔티티의 일부 필드에 대해 생성되는 setter 함수를 제거하였습니다.

## 관련 이슈

* **Close #6**