### PR TITLE
Coroutine을 Reactive Streams로 마이그레이션

### DIFF
--- a/src/main/kotlin/com/quizit/user/domain/User.kt
+++ b/src/main/kotlin/com/quizit/user/domain/User.kt
@@ -11,17 +11,17 @@ class User(
     @Id
     var id: String? = null,
     val username: String,
-    val password: String,
-    val nickname: String,
-    val image: String,
+    var password: String,
+    var nickname: String,
+    var image: String,
     var level: Int,
     val role: Role,
-    val allowPush: Boolean,
-    val dailyTarget: Int,
+    var allowPush: Boolean,
+    var dailyTarget: Int,
     var answerRate: Double,
-    val correctQuizIds: MutableSet<String>,
-    val incorrectQuizIds: MutableSet<String>,
-    val markedQuizIds: MutableSet<String>,
+    val correctQuizIds: HashSet<String>,
+    val incorrectQuizIds: HashSet<String>,
+    val markedQuizIds: HashSet<String>,
     @CreatedDate
     var createdDate: LocalDateTime = LocalDateTime.now()
 ) {
@@ -52,4 +52,15 @@ class User(
     private fun changeAnswerRate() {
         answerRate = (correctQuizIds.size.toDouble() / (correctQuizIds.size + incorrectQuizIds.size).toDouble()) * 100
     }
+
+    fun update(nickname: String, image: String, allowPush: Boolean, dailyTarget: Int): User =
+        also {
+            it.nickname = nickname
+            it.image = image
+            it.allowPush = allowPush
+            it.dailyTarget = dailyTarget
+        }
+
+    fun updatePassword(password: String): User =
+        also { it.password = password }
 }

--- a/src/main/kotlin/com/quizit/user/dto/response/UserResponse.kt
+++ b/src/main/kotlin/com/quizit/user/dto/response/UserResponse.kt
@@ -15,9 +15,9 @@ data class UserResponse(
     val dailyTarget: Int,
     val answerRate: Double,
     val createdDate: LocalDateTime,
-    val correctQuizIds: Set<String>,
-    val incorrectQuizIds: Set<String>,
-    val markedQuizIds: Set<String>
+    val correctQuizIds: HashSet<String>,
+    val incorrectQuizIds: HashSet<String>,
+    val markedQuizIds: HashSet<String>
 ) {
     companion object {
         operator fun invoke(user: User): UserResponse =

--- a/src/main/kotlin/com/quizit/user/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/user/global/config/SecurityConfiguration.kt
@@ -51,7 +51,7 @@ class SecurityConfiguration {
 }
 
 fun ServerRequest.authentication(): Mono<DefaultJwtAuthentication> =
-    principal().cast(DefaultJwtAuthentication::class.java)
+    principal()
+        .cast(DefaultJwtAuthentication::class.java)
 
-fun DefaultJwtAuthentication.isAdmin(): Boolean =
-    isAuthenticated && (authorities[0] == SimpleGrantedAuthority("ADMIN"))
+fun DefaultJwtAuthentication.isAdmin(): Boolean = isAuthenticated && (authorities[0] == SimpleGrantedAuthority("ADMIN"))

--- a/src/main/kotlin/com/quizit/user/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/user/global/config/SecurityConfiguration.kt
@@ -15,8 +15,6 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository
-import org.springframework.web.reactive.function.server.ServerRequest
-import org.springframework.web.reactive.function.server.awaitPrincipal
 
 @Configuration
 @EnableWebFluxSecurity
@@ -50,8 +48,5 @@ class SecurityConfiguration {
         }
 }
 
-suspend fun ServerRequest.awaitAuthentication(): DefaultJwtAuthentication =
-    this.awaitPrincipal() as DefaultJwtAuthentication
-
 fun DefaultJwtAuthentication.isAdmin(): Boolean =
-    this.isAuthenticated and (this.authorities[0] == SimpleGrantedAuthority("ADMIN"))
+    isAuthenticated and (authorities[0] == SimpleGrantedAuthority("ADMIN"))

--- a/src/main/kotlin/com/quizit/user/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/user/global/config/SecurityConfiguration.kt
@@ -15,6 +15,8 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository
+import org.springframework.web.reactive.function.server.ServerRequest
+import reactor.core.publisher.Mono
 
 @Configuration
 @EnableWebFluxSecurity
@@ -48,5 +50,8 @@ class SecurityConfiguration {
         }
 }
 
+fun ServerRequest.authentication(): Mono<DefaultJwtAuthentication> =
+    principal().cast(DefaultJwtAuthentication::class.java)
+
 fun DefaultJwtAuthentication.isAdmin(): Boolean =
-    isAuthenticated and (authorities[0] == SimpleGrantedAuthority("ADMIN"))
+    isAuthenticated && (authorities[0] == SimpleGrantedAuthority("ADMIN"))

--- a/src/main/kotlin/com/quizit/user/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/user/global/config/SecurityConfiguration.kt
@@ -3,6 +3,7 @@ package com.quizit.user.global.config
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.authentication.JwtAuthenticationFilter
 import com.github.jwt.core.JwtProvider
+import com.quizit.user.domain.enum.Role
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
@@ -34,7 +35,7 @@ class SecurityConfiguration {
             securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
             authorizeExchange {
                 it.pathMatchers("/user/admin/**")
-                    .hasAuthority("ADMIN")
+                    .hasAuthority(Role.ADMIN.name)
                     .pathMatchers(
                         "/actuator/health/**",
                         "/user",
@@ -54,4 +55,5 @@ fun ServerRequest.authentication(): Mono<DefaultJwtAuthentication> =
     principal()
         .cast(DefaultJwtAuthentication::class.java)
 
-fun DefaultJwtAuthentication.isAdmin(): Boolean = isAuthenticated && (authorities[0] == SimpleGrantedAuthority("ADMIN"))
+fun DefaultJwtAuthentication.isAdmin(): Boolean =
+    isAuthenticated && (authorities[0] == SimpleGrantedAuthority(Role.ADMIN.name))

--- a/src/main/kotlin/com/quizit/user/global/config/WebFluxConfiguration.kt
+++ b/src/main/kotlin/com/quizit/user/global/config/WebFluxConfiguration.kt
@@ -11,9 +11,10 @@ class WebFluxConfiguration(
     private val frontendUrl: String
 ) : WebFluxConfigurer {
     override fun addCorsMappings(registry: CorsRegistry) {
-        registry.addMapping("/**").apply {
-            allowedOrigins(frontendUrl)
-            allowCredentials(true)
-        }
+        registry.addMapping("/**")
+            .apply {
+                allowedOrigins(frontendUrl)
+                allowCredentials(true)
+            }
     }
 }

--- a/src/main/kotlin/com/quizit/user/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/quizit/user/global/exception/GlobalExceptionHandler.kt
@@ -3,8 +3,6 @@ package com.quizit.user.global.exception
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.quizit.user.global.dto.ErrorResponse
 import com.quizit.user.global.util.logger
-import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.reactor.mono
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatusCode
@@ -17,20 +15,23 @@ import reactor.kotlin.core.publisher.toMono
 class GlobalExceptionHandler(
     private val objectMapper: ObjectMapper
 ) : ErrorWebExceptionHandler {
-    override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> = mono {
-        logger.error { "${ex.message} at ${ex.stackTrace[0]}" }
-
-        val errorResponse = if (ex is ServerException) {
-            ErrorResponse(code = ex.code, message = ex.message)
-        } else {
-            ErrorResponse(code = 500, message = "Internal Server Error")
-        }
-
+    override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> =
         with(exchange.response) {
+            val errorResponse = if (ex is ServerException) {
+                ErrorResponse(code = ex.code, message = ex.message)
+            } else {
+                ErrorResponse(code = 500, message = "Internal Server Error")
+            }
+
+            logger.error { "${ex.message} at ${ex.stackTrace[0]}" }
+
             statusCode = HttpStatusCode.valueOf(errorResponse.code)
             headers.contentType = MediaType.APPLICATION_JSON
 
-            writeWith(bufferFactory().wrap(objectMapper.writeValueAsBytes(errorResponse)).toMono()).awaitSingleOrNull()
+            writeWith(
+                bufferFactory()
+                    .wrap(objectMapper.writeValueAsBytes(errorResponse))
+                    .toMono()
+            )
         }
-    }
 }

--- a/src/main/kotlin/com/quizit/user/global/util/KotlinUtil.kt
+++ b/src/main/kotlin/com/quizit/user/global/util/KotlinUtil.kt
@@ -1,0 +1,7 @@
+package com.quizit.user.global.util
+
+import reactor.util.function.Tuple2
+
+operator fun <T1, T2> Tuple2<T1, T2>.component1(): T1 = t1
+
+operator fun <T1, T2> Tuple2<T1, T2>.component2(): T2 = t2

--- a/src/main/kotlin/com/quizit/user/handler/UserHandler.kt
+++ b/src/main/kotlin/com/quizit/user/handler/UserHandler.kt
@@ -1,10 +1,12 @@
 package com.quizit.user.handler
 
-import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.quizit.user.dto.request.ChangePasswordRequest
 import com.quizit.user.dto.request.CreateUserRequest
 import com.quizit.user.dto.request.MatchPasswordRequest
 import com.quizit.user.dto.request.UpdateUserByIdRequest
+import com.quizit.user.global.config.authentication
+import com.quizit.user.global.util.component1
+import com.quizit.user.global.util.component2
 import com.quizit.user.service.UserService
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.ServerRequest
@@ -49,28 +51,28 @@ class UserHandler(
 
     fun updateUserById(request: ServerRequest): Mono<ServerResponse> =
         with(request) {
-            Mono.zip(principal(), bodyToMono<UpdateUserByIdRequest>())
-                .flatMap {
+            Mono.zip(authentication(), bodyToMono<UpdateUserByIdRequest>())
+                .flatMap { (authentication, request) ->
                     ServerResponse.ok()
-                        .body(userService.updateUserById(pathVariable("id"), it.t1 as DefaultJwtAuthentication, it.t2))
+                        .body(userService.updateUserById(pathVariable("id"), authentication, request))
                 }
         }
 
     fun changePassword(request: ServerRequest): Mono<ServerResponse> =
         with(request) {
-            Mono.zip(principal(), bodyToMono<ChangePasswordRequest>())
-                .flatMap {
+            Mono.zip(authentication(), bodyToMono<ChangePasswordRequest>())
+                .flatMap { (authentication, request) ->
                     ServerResponse.ok()
-                        .body(userService.changePassword(pathVariable("id"), it.t1 as DefaultJwtAuthentication, it.t2))
+                        .body(userService.changePassword(pathVariable("id"), authentication, request))
                 }
         }
 
     fun deleteUserById(request: ServerRequest): Mono<ServerResponse> =
         with(request) {
-            principal()
+            authentication()
                 .flatMap {
                     ServerResponse.ok()
-                        .body(userService.deleteUserById(pathVariable("id"), it as DefaultJwtAuthentication))
+                        .body(userService.deleteUserById(pathVariable("id"), it))
                 }
         }
 }

--- a/src/main/kotlin/com/quizit/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/quizit/user/repository/UserRepository.kt
@@ -1,14 +1,15 @@
 package com.quizit.user.repository
 
 import com.quizit.user.domain.User
-import kotlinx.coroutines.flow.Flow
 import org.springframework.data.mongodb.repository.Aggregation
-import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import org.springframework.stereotype.Repository
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @Repository
-interface UserRepository : CoroutineCrudRepository<User, String> {
-    suspend fun findByUsername(username: String): User?
+interface UserRepository : ReactiveMongoRepository<User, String> {
+    fun findByUsername(username: String): Mono<User>
 
     @Aggregation(
         pipeline = [
@@ -16,5 +17,5 @@ interface UserRepository : CoroutineCrudRepository<User, String> {
             "{ \$sort: { quizCount: -1 } }"
         ]
     )
-    fun findAllOrderByCorrectQuizIdsSize(): Flow<User>
+    fun findAllOrderByCorrectQuizIdsSize(): Flux<User>
 }

--- a/src/main/kotlin/com/quizit/user/router/UserRouter.kt
+++ b/src/main/kotlin/com/quizit/user/router/UserRouter.kt
@@ -5,13 +5,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.coRouter
+import org.springframework.web.reactive.function.server.router
 
 @Configuration
 class UserRouter {
     @Bean
     fun userRoutes(handler: UserHandler): RouterFunction<ServerResponse> =
-        coRouter {
+        router {
             "/user".nest {
                 GET("/ranking", handler::getRanking)
                 GET("/{id}", handler::getUserById)

--- a/src/main/kotlin/com/quizit/user/service/UserService.kt
+++ b/src/main/kotlin/com/quizit/user/service/UserService.kt
@@ -27,7 +27,7 @@ class UserService(
 ) {
     fun getRanking(): Flux<UserResponse> =
         userRepository.findAllOrderByCorrectQuizIdsSize()
-            .flatMap { Mono.just(UserResponse(it)) }
+            .map { UserResponse(it) }
 
     fun getUserById(id: String): Mono<UserResponse> =
         userRepository.findById(id)

--- a/src/main/kotlin/com/quizit/user/service/UserService.kt
+++ b/src/main/kotlin/com/quizit/user/service/UserService.kt
@@ -15,116 +15,139 @@ import com.quizit.user.exception.UserNotFoundException
 import com.quizit.user.exception.UsernameAlreadyExistException
 import com.quizit.user.global.config.isAdmin
 import com.quizit.user.repository.UserRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @Service
 class UserService(
     private val userRepository: UserRepository,
     private val passwordEncoder: PasswordEncoder
 ) {
-    fun getRanking(): Flow<UserResponse> =
+    fun getRanking(): Flux<UserResponse> =
         userRepository.findAllOrderByCorrectQuizIdsSize()
+            .flatMap { Mono.just(UserResponse(it)) }
+
+    fun getUserById(id: String): Mono<UserResponse> =
+        userRepository.findById(id)
+            .switchIfEmpty(Mono.error(UserNotFoundException()))
             .map { UserResponse(it) }
 
-    suspend fun getUserById(id: String): UserResponse =
-        userRepository.findById(id)?.let { UserResponse(it) } ?: throw UserNotFoundException()
+    fun getUserByUsername(username: String): Mono<UserResponse> =
+        userRepository.findByUsername(username)
+            .switchIfEmpty(Mono.error(UserNotFoundException()))
+            .map { UserResponse(it) }
 
-    suspend fun getUserByUsername(username: String): UserResponse =
-        userRepository.findByUsername(username)?.let { UserResponse(it) } ?: throw UserNotFoundException()
-
-    suspend fun matchPassword(username: String, request: MatchPasswordRequest): MatchPasswordResponse =
+    fun matchPassword(username: String, request: MatchPasswordRequest): Mono<MatchPasswordResponse> =
         with(request) {
-            userRepository.findByUsername(username)?.let {
-                MatchPasswordResponse(passwordEncoder.matches(password, it.password))
-            } ?: throw UserNotFoundException()
+            userRepository.findByUsername(username)
+                .switchIfEmpty(Mono.error(UserNotFoundException()))
+                .map { MatchPasswordResponse(passwordEncoder.matches(password, it.password)) }
         }
 
-    suspend fun createUser(request: CreateUserRequest): UserResponse =
+    fun createUser(request: CreateUserRequest): Mono<UserResponse> =
         with(request) {
-            userRepository.findByUsername(username)?.run { throw UsernameAlreadyExistException() }
-            userRepository.save(
-                User(
-                    username = username,
-                    password = passwordEncoder.encode(password),
-                    nickname = nickname,
-                    image = image,
-                    level = 1,
-                    role = Role.USER,
-                    allowPush = allowPush,
-                    dailyTarget = dailyTarget,
-                    answerRate = 0.0,
-                    correctQuizIds = mutableSetOf(),
-                    incorrectQuizIds = mutableSetOf(),
-                    markedQuizIds = mutableSetOf(),
-                )
-            ).let { UserResponse(it) }
-        }
-
-    suspend fun updateUserById(
-        id: String, authentication: DefaultJwtAuthentication, request: UpdateUserByIdRequest
-    ): UserResponse =
-        with(request) {
-            userRepository.findById(id)?.let {
-                if ((authentication.id == it.id) || authentication.isAdmin()) {
-                    userRepository.save(
-                        User(
-                            id = id,
-                            username = it.username,
-                            password = it.password,
-                            nickname = nickname,
-                            image = image,
-                            level = it.level,
-                            role = it.role,
-                            allowPush = allowPush,
-                            dailyTarget = dailyTarget,
-                            answerRate = it.answerRate,
-                            correctQuizIds = it.correctQuizIds,
-                            incorrectQuizIds = it.incorrectQuizIds,
-                            markedQuizIds = it.markedQuizIds
+            userRepository.findByUsername(username)
+                .flatMap { Mono.error<User>(UsernameAlreadyExistException()) }
+                .switchIfEmpty(
+                    Mono.defer {
+                        userRepository.save(
+                            User(
+                                username = username,
+                                password = passwordEncoder.encode(password),
+                                nickname = nickname,
+                                image = image,
+                                level = 1,
+                                role = Role.USER,
+                                allowPush = allowPush,
+                                dailyTarget = dailyTarget,
+                                answerRate = 0.0,
+                                correctQuizIds = mutableSetOf(),
+                                incorrectQuizIds = mutableSetOf(),
+                                markedQuizIds = mutableSetOf(),
+                            )
                         )
-                    )
-                } else throw PermissionDeniedException()
-            }?.let { UserResponse(it) } ?: throw UserNotFoundException()
+                    }
+                )
+                .map { UserResponse(it) }
         }
 
-    suspend fun changePassword(
-        id: String, authentication: DefaultJwtAuthentication, request: ChangePasswordRequest
-    ) {
+    fun updateUserById(
+        id: String, authentication: DefaultJwtAuthentication, request: UpdateUserByIdRequest
+    ): Mono<UserResponse> =
         with(request) {
-            userRepository.findById(id)?.let {
-                if ((authentication.id == it.id) || authentication.isAdmin()) {
-                    if (passwordEncoder.matches(password, it.password)) {
+            userRepository.findById(id)
+                .switchIfEmpty(Mono.error(UserNotFoundException()))
+                .flatMap {
+                    if ((authentication.id == it.id) || authentication.isAdmin()) {
                         userRepository.save(
                             User(
                                 id = id,
                                 username = it.username,
-                                password = passwordEncoder.encode(newPassword),
-                                nickname = it.nickname,
-                                image = it.image,
+                                password = it.password,
+                                nickname = nickname,
+                                image = image,
                                 level = it.level,
                                 role = it.role,
-                                allowPush = it.allowPush,
-                                dailyTarget = it.dailyTarget,
+                                allowPush = allowPush,
+                                dailyTarget = dailyTarget,
                                 answerRate = it.answerRate,
                                 correctQuizIds = it.correctQuizIds,
                                 incorrectQuizIds = it.incorrectQuizIds,
                                 markedQuizIds = it.markedQuizIds
                             )
                         )
-                    } else throw PasswordNotMatchException()
-                } else throw PermissionDeniedException()
-            }?.let { UserResponse(it) } ?: throw UserNotFoundException()
+                    } else {
+                        Mono.error(PermissionDeniedException())
+                    }
+                }
+                .map { UserResponse(it) }
         }
-    }
 
-    suspend fun deleteUserById(id: String, authentication: DefaultJwtAuthentication) {
-        userRepository.findById(id)?.let {
-            if ((authentication.id == it.id) || authentication.isAdmin()) {
-                userRepository.deleteById(id)
-            } else throw PermissionDeniedException()
-        } ?: throw UserNotFoundException()
-    }
+    fun changePassword(
+        id: String, authentication: DefaultJwtAuthentication, request: ChangePasswordRequest
+    ): Mono<Void> =
+        with(request) {
+            userRepository.findById(id)
+                .switchIfEmpty(Mono.error(UserNotFoundException()))
+                .flatMap {
+                    if ((authentication.id == it.id) || authentication.isAdmin()) {
+                        if (passwordEncoder.matches(password, it.password)) {
+                            userRepository.save(
+                                User(
+                                    id = id,
+                                    username = it.username,
+                                    password = passwordEncoder.encode(newPassword),
+                                    nickname = it.nickname,
+                                    image = it.image,
+                                    level = it.level,
+                                    role = it.role,
+                                    allowPush = it.allowPush,
+                                    dailyTarget = it.dailyTarget,
+                                    answerRate = it.answerRate,
+                                    correctQuizIds = it.correctQuizIds,
+                                    incorrectQuizIds = it.incorrectQuizIds,
+                                    markedQuizIds = it.markedQuizIds
+                                )
+                            ).then()
+                        } else {
+                            Mono.error(PasswordNotMatchException())
+                        }
+                    } else {
+                        Mono.error(PermissionDeniedException())
+                    }
+                }
+        }
+
+    fun deleteUserById(id: String, authentication: DefaultJwtAuthentication): Mono<Void> =
+        userRepository.findById(id)
+            .switchIfEmpty(Mono.error(UserNotFoundException()))
+            .flatMap {
+                if ((authentication.id == it.id) || authentication.isAdmin()) {
+                    userRepository.deleteById(id)
+                } else {
+                    Mono.error(PermissionDeniedException())
+                }
+            }
 }

--- a/src/test/kotlin/com/quizit/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/quizit/user/controller/UserControllerTest.kt
@@ -14,7 +14,6 @@ import com.quizit.user.handler.UserHandler
 import com.quizit.user.router.UserRouter
 import com.quizit.user.service.UserService
 import com.quizit.user.util.*
-import io.mockk.coEvery
 import io.mockk.every
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.restdocs.operation.preprocess.Preprocessors
@@ -128,7 +127,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 식별자가 주어지면") {
-                every { userService.getUserById(any()) } returns Mono.error(UserNotFoundException())
+                every { userService.getUserById(any()) } throws UserNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -177,7 +176,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 아이디가 주어지면") {
-                every { userService.getUserByUsername(any()) } returns Mono.error(UserNotFoundException())
+                every { userService.getUserByUsername(any()) } throws UserNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -228,7 +227,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("이미 존재하는 아이디가 주어지면") {
-                every { userService.createUser(any()) } returns Mono.error(UsernameAlreadyExistException())
+                every { userService.createUser(any()) } throws UsernameAlreadyExistException()
                 withMockUser()
 
                 it("상태 코드 409와 에러를 반환한다.") {
@@ -280,7 +279,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 아이디가 주어지면") {
-                every { userService.matchPassword(any(), any()) } returns Mono.error(UserNotFoundException())
+                every { userService.matchPassword(any(), any()) } throws UserNotFoundException()
 
                 it("상태 코드 404와 에러를 반환한다.") {
                     webClient
@@ -331,7 +330,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 식별자가 주어지면") {
-                every { userService.updateUserById(any(), any(), any()) } returns Mono.error(UserNotFoundException())
+                every { userService.updateUserById(any(), any(), any()) } throws UserNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -356,9 +355,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("본인이 아닌 다른 유저의 식별자가 주어지면") {
-                every { userService.updateUserById(any(), any(), any()) } returns Mono.error(
-                    PermissionDeniedException()
-                )
+                every { userService.updateUserById(any(), any(), any()) } throws PermissionDeniedException()
                 withMockUser()
 
                 it("상태 코드 403과 에러를 반환한다.") {
@@ -409,7 +406,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 식별자가 주어지면") {
-                every { userService.changePassword(any(), any(), any()) } returns Mono.error(UserNotFoundException())
+                every { userService.changePassword(any(), any(), any()) } throws UserNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -434,9 +431,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("본인이 아닌 다른 유저의 식별자가 주어지면") {
-                every { userService.changePassword(any(), any(), any()) } returns Mono.error(
-                    PermissionDeniedException()
-                )
+                every { userService.changePassword(any(), any(), any()) } throws PermissionDeniedException()
                 withMockUser()
 
                 it("상태 코드 403과 에러를 반환한다.") {
@@ -461,9 +456,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("현재 패스워드가 일치하지 않으면") {
-                every { userService.changePassword(any(), any(), any()) } returns Mono.error(
-                    PasswordNotMatchException()
-                )
+                every { userService.changePassword(any(), any(), any()) } throws PasswordNotMatchException()
                 withMockUser()
 
                 it("상태 코드 400과 에러를 반환한다.") {
@@ -512,7 +505,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 식별자가 주어지면") {
-                every { userService.deleteUserById(any(), any()) } returns Mono.error(UserNotFoundException())
+                every { userService.deleteUserById(any(), any()) } throws UserNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -535,7 +528,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("본인이 아닌 다른 유저의 식별자가 주어지면") {
-                coEvery { userService.deleteUserById(any(), any()) } returns Mono.error(PermissionDeniedException())
+                every { userService.deleteUserById(any(), any()) } throws PermissionDeniedException()
                 withMockUser()
 
                 it("상태 코드 403과 에러를 반환한다.") {

--- a/src/test/kotlin/com/quizit/user/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/quizit/user/controller/UserControllerTest.kt
@@ -15,14 +15,14 @@ import com.quizit.user.router.UserRouter
 import com.quizit.user.service.UserService
 import com.quizit.user.util.*
 import io.mockk.coEvery
-import io.mockk.just
-import io.mockk.runs
-import kotlinx.coroutines.flow.flowOf
+import io.mockk.every
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.restdocs.operation.preprocess.Preprocessors
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @WebFluxTest(UserRouter::class, UserHandler::class)
 class UserControllerTest : BaseControllerTest() {
@@ -79,7 +79,7 @@ class UserControllerTest : BaseControllerTest() {
     init {
         describe("getRanking()은") {
             context("요청이 주어지면") {
-                coEvery { userService.getRanking() } returns flowOf(createUserResponse())
+                every { userService.getRanking() } returns Flux.just(createUserResponse())
                 withMockUser()
 
                 it("상태 코드 200과 랭킹 순서에 맞게 userResponse들을 반환한다.") {
@@ -104,7 +104,7 @@ class UserControllerTest : BaseControllerTest() {
 
         describe("getUserById()는") {
             context("존재하는 유저에 대한 식별자가 주어지면") {
-                coEvery { userService.getUserById(any()) } returns createUserResponse()
+                every { userService.getUserById(any()) } returns Mono.just(createUserResponse())
                 withMockUser()
 
                 it("상태 코드 200과 userResponse를 반환한다.") {
@@ -128,7 +128,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 식별자가 주어지면") {
-                coEvery { userService.getUserById(any()) } throws UserNotFoundException()
+                every { userService.getUserById(any()) } returns Mono.error(UserNotFoundException())
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -154,7 +154,7 @@ class UserControllerTest : BaseControllerTest() {
 
         describe("getUserByUsername()은") {
             context("존재하는 유저에 대한 아이디가 주어지면") {
-                coEvery { userService.getUserByUsername(any()) } returns createUserResponse()
+                every { userService.getUserByUsername(any()) } returns Mono.just(createUserResponse())
 
                 it("상태 코드 200과 userResponse를 반환한다.") {
                     webClient
@@ -177,7 +177,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 아이디가 주어지면") {
-                coEvery { userService.getUserByUsername(any()) } throws UserNotFoundException()
+                every { userService.getUserByUsername(any()) } returns Mono.error(UserNotFoundException())
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -203,7 +203,7 @@ class UserControllerTest : BaseControllerTest() {
 
         describe("createUser()는") {
             context("존재하지 않는 아이디가 주어지면") {
-                coEvery { userService.createUser(any()) } returns createUserResponse()
+                every { userService.createUser(any()) } returns Mono.just(createUserResponse())
                 withMockUser()
 
                 it("상태 코드 200과 userResponse를 반환한다.") {
@@ -228,7 +228,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("이미 존재하는 아이디가 주어지면") {
-                coEvery { userService.createUser(any()) } throws UsernameAlreadyExistException()
+                every { userService.createUser(any()) } returns Mono.error(UsernameAlreadyExistException())
                 withMockUser()
 
                 it("상태 코드 409와 에러를 반환한다.") {
@@ -255,7 +255,7 @@ class UserControllerTest : BaseControllerTest() {
 
         describe("matchPassword()는") {
             context("존재하는 유저에 대한 아이디가 주어지면") {
-                coEvery { userService.matchPassword(any(), any()) } returns createMatchPasswordResponse()
+                every { userService.matchPassword(any(), any()) } returns Mono.just(createMatchPasswordResponse())
 
                 it("상태 코드 200과 matchPasswordResponse를 반환한다.") {
                     webClient
@@ -280,7 +280,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 아이디가 주어지면") {
-                coEvery { userService.matchPassword(any(), any()) } throws UserNotFoundException()
+                every { userService.matchPassword(any(), any()) } returns Mono.error(UserNotFoundException())
 
                 it("상태 코드 404와 에러를 반환한다.") {
                     webClient
@@ -307,7 +307,7 @@ class UserControllerTest : BaseControllerTest() {
 
         describe("updateUserById()는") {
             context("존재하는 유저에 대한 식별자가 주어지면") {
-                coEvery { userService.updateUserById(any(), any(), any()) } returns createUserResponse()
+                every { userService.updateUserById(any(), any(), any()) } returns Mono.just(createUserResponse())
                 withMockUser()
 
                 it("상태 코드 200과 userResponse를 반환한다.") {
@@ -331,7 +331,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 식별자가 주어지면") {
-                coEvery { userService.updateUserById(any(), any(), any()) } throws UserNotFoundException()
+                every { userService.updateUserById(any(), any(), any()) } returns Mono.error(UserNotFoundException())
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -356,7 +356,9 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("본인이 아닌 다른 유저의 식별자가 주어지면") {
-                coEvery { userService.updateUserById(any(), any(), any()) } throws PermissionDeniedException()
+                every { userService.updateUserById(any(), any(), any()) } returns Mono.error(
+                    PermissionDeniedException()
+                )
                 withMockUser()
 
                 it("상태 코드 403과 에러를 반환한다.") {
@@ -383,7 +385,7 @@ class UserControllerTest : BaseControllerTest() {
 
         describe("changePassword()는") {
             context("존재하는 유저에 대한 식별자가 주어지면") {
-                coEvery { userService.changePassword(any(), any(), any()) } just runs
+                every { userService.changePassword(any(), any(), any()) } returns Mono.empty()
                 withMockUser()
 
                 it("상태 코드 200을 반환한다.") {
@@ -407,7 +409,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 식별자가 주어지면") {
-                coEvery { userService.changePassword(any(), any(), any()) } throws UserNotFoundException()
+                every { userService.changePassword(any(), any(), any()) } returns Mono.error(UserNotFoundException())
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -432,7 +434,9 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("본인이 아닌 다른 유저의 식별자가 주어지면") {
-                coEvery { userService.changePassword(any(), any(), any()) } throws PermissionDeniedException()
+                every { userService.changePassword(any(), any(), any()) } returns Mono.error(
+                    PermissionDeniedException()
+                )
                 withMockUser()
 
                 it("상태 코드 403과 에러를 반환한다.") {
@@ -457,7 +461,9 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("현재 패스워드가 일치하지 않으면") {
-                coEvery { userService.changePassword(any(), any(), any()) } throws PasswordNotMatchException()
+                every { userService.changePassword(any(), any(), any()) } returns Mono.error(
+                    PasswordNotMatchException()
+                )
                 withMockUser()
 
                 it("상태 코드 400과 에러를 반환한다.") {
@@ -484,7 +490,7 @@ class UserControllerTest : BaseControllerTest() {
 
         describe("deleteUserById()는") {
             context("존재하는 유저에 대한 식별자가 주어지면") {
-                coEvery { userService.deleteUserById(any(), any()) } just runs
+                every { userService.deleteUserById(any(), any()) } returns Mono.empty()
                 withMockUser()
 
                 it("상태 코드 200을 반환한다.") {
@@ -506,7 +512,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("존재하지 않는 유저에 대한 식별자가 주어지면") {
-                coEvery { userService.deleteUserById(any(), any()) } throws UserNotFoundException()
+                every { userService.deleteUserById(any(), any()) } returns Mono.error(UserNotFoundException())
                 withMockUser()
 
                 it("상태 코드 404와 에러를 반환한다.") {
@@ -529,7 +535,7 @@ class UserControllerTest : BaseControllerTest() {
             }
 
             context("본인이 아닌 다른 유저의 식별자가 주어지면") {
-                coEvery { userService.deleteUserById(any(), any()) } throws PermissionDeniedException()
+                coEvery { userService.deleteUserById(any(), any()) } returns Mono.error(PermissionDeniedException())
                 withMockUser()
 
                 it("상태 코드 403과 에러를 반환한다.") {

--- a/src/test/kotlin/com/quizit/user/domain/UserTest.kt
+++ b/src/test/kotlin/com/quizit/user/domain/UserTest.kt
@@ -1,22 +1,28 @@
 package com.quizit.user.domain
 
-import com.quizit.user.fixture.ID
-import com.quizit.user.fixture.createUser
+import com.quizit.user.fixture.*
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+import io.kotest.matchers.equals.shouldNotBeEqual
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.ints.shouldBeLessThan
 
 class UserTest : BehaviorSpec() {
     init {
         Given("유저가 존재하는 경우") {
-            val user = createUser()
+            val user = createUser().apply {
+                nickname = NICKNAME
+                password = passwordEncoder.encode(PASSWORD)
+                level = LEVEL
+                allowPush = ALLOW_PUSH
+                dailyTarget = DAILY_TARGET
+            } // Code Coverage
 
             When("유저가 퀴즈의 정답을 맞췄다면") {
-                val correctAnswerUser = createUser().apply {
-                    correctAnswer(ID)
-                }
+                val correctAnswerUser = createUser()
+                    .apply { correctAnswer(ID) }
 
                 Then("해당 유저의 정답률이 상승한다.") {
                     correctAnswerUser.answerRate shouldBeGreaterThan user.answerRate
@@ -24,7 +30,8 @@ class UserTest : BehaviorSpec() {
             }
 
             When("유저가 퀴즈의 정답을 틀렸다면") {
-                val incorrectAnswerUser = createUser().apply { incorrectAnswer(ID) }
+                val incorrectAnswerUser = createUser()
+                    .apply { incorrectAnswer(ID) }
 
                 Then("해당 유저의 정답률이 감소한다.") {
                     incorrectAnswerUser.answerRate shouldBeLessThan user.answerRate
@@ -32,7 +39,8 @@ class UserTest : BehaviorSpec() {
             }
 
             When("유저가 퀴즈를 저장했다면") {
-                val markUser = createUser().apply { markQuiz(ID) }
+                val markUser = createUser()
+                    .apply { markQuiz(ID) }
 
                 Then("해당 퀴즈가 유저의 저장한 퀴즈에 추가된다.") {
                     markUser.markedQuizIds.size shouldBeGreaterThan user.markedQuizIds.size
@@ -40,7 +48,8 @@ class UserTest : BehaviorSpec() {
             }
 
             When("유저가 퀴즈를 저장 취소했다면") {
-                val unmarkUser = createUser().apply { unmarkQuiz(markedQuizIds.random()) }
+                val unmarkUser = createUser()
+                    .apply { unmarkQuiz(markedQuizIds.random()) }
 
                 Then("해당 퀴즈가 유저의 저장한 퀴즈에서 삭제된다.") {
                     unmarkUser.markedQuizIds.size shouldBeLessThan user.markedQuizIds.size
@@ -48,13 +57,32 @@ class UserTest : BehaviorSpec() {
             }
 
             When("유저의 경험치가 일정 수준 이상 도달했다면") {
-                val levelUpUser = createUser().apply {
-                    correctQuizIds.addAll((1..level * 5).map { "quiz_$it" })
-                    checkLevel()
-                }
+                val levelUpUser = createUser()
+                    .apply {
+                        correctQuizIds.addAll((1..level * 5).map { "quiz_$it" })
+                        checkLevel()
+                    }
 
                 Then("해당 유저의 레벨이 증가한다.") {
                     levelUpUser.level shouldBeGreaterThan user.level
+                }
+            }
+
+            When("유저가 프로필을 수정한다면") {
+                val updatedUser = createUser(nickname = "updated_nickname")
+                    .apply { update(nickname, image, allowPush, dailyTarget) }
+
+                Then("해당 유저의 정보가 수정된다.") {
+                    updatedUser shouldNotBeEqualToComparingFields user
+                }
+            }
+
+            When("유저가 패스워드를 변경한다면") {
+                val updatedUser = createUser(password = "updated_password")
+                    .apply { updatePassword(passwordEncoder.encode(password)) }
+
+                Then("해당 유저의 패스워드가 변경된다.") {
+                    updatedUser.password shouldNotBeEqual user.password
                 }
             }
         }

--- a/src/test/kotlin/com/quizit/user/domain/UserTest.kt
+++ b/src/test/kotlin/com/quizit/user/domain/UserTest.kt
@@ -59,7 +59,7 @@ class UserTest : BehaviorSpec() {
             When("유저의 경험치가 일정 수준 이상 도달했다면") {
                 val levelUpUser = createUser()
                     .apply {
-                        correctQuizIds.addAll((1..level * 5).map { "quiz_$it" })
+                        correctQuizIds.addAll((1..level * 5).map { "$it" })
                         checkLevel()
                     }
 

--- a/src/test/kotlin/com/quizit/user/fixture/JwtFixture.kt
+++ b/src/test/kotlin/com/quizit/user/fixture/JwtFixture.kt
@@ -9,9 +9,7 @@ val SECRET_KEY = (1..100).map { ('a'..'z').random() }.joinToString("")
 const val ACCESS_TOKEN_EXPIRE = 5L
 const val REFRESH_TOKEN_EXPIRE = 10L
 val AUTHORITIES = listOf(SimpleGrantedAuthority("USER"))
-val jwtProvider = JwtConfiguration().jwtProvider(
-    secretKey = SECRET_KEY, accessTokenExpire = ACCESS_TOKEN_EXPIRE, refreshTokenExpire = REFRESH_TOKEN_EXPIRE
-)
+val jwtProvider = JwtConfiguration().jwtProvider(SECRET_KEY, ACCESS_TOKEN_EXPIRE, REFRESH_TOKEN_EXPIRE)
 
 fun createJwtAuthentication(
     id: String = ID,

--- a/src/test/kotlin/com/quizit/user/fixture/JwtFixture.kt
+++ b/src/test/kotlin/com/quizit/user/fixture/JwtFixture.kt
@@ -2,13 +2,14 @@ package com.quizit.user.fixture
 
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.config.JwtConfiguration
+import com.quizit.user.domain.enum.Role
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 val SECRET_KEY = (1..100).map { ('a'..'z').random() }.joinToString("")
 const val ACCESS_TOKEN_EXPIRE = 5L
 const val REFRESH_TOKEN_EXPIRE = 10L
-val AUTHORITIES = listOf(SimpleGrantedAuthority("USER"))
+val AUTHORITIES = listOf(SimpleGrantedAuthority(Role.USER.name))
 val jwtProvider = JwtConfiguration().jwtProvider(SECRET_KEY, ACCESS_TOKEN_EXPIRE, REFRESH_TOKEN_EXPIRE)
 
 fun createJwtAuthentication(

--- a/src/test/kotlin/com/quizit/user/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/quizit/user/fixture/UserFixture.kt
@@ -14,15 +14,15 @@ import java.time.LocalDateTime
 const val USERNAME = "earlgrey02@github.com"
 const val NICKNAME = "earlgrey02"
 const val PASSWORD = "root"
-const val IMAGE = "test"
+const val IMAGE = "http://localhost:8080/image.jpg"
 const val LEVEL = 2
 val ROLE = Role.USER
 const val ALLOW_PUSH = true
 const val DAILY_TARGET = 10
 const val ANSWER_RATE = 50.0
-val CORRECT_QUIZ_IDS = mutableSetOf("quiz_1")
-val INCORRECT_QUIZ_IDS = mutableSetOf("quiz_1")
-val MARKED_QUIZ_IDS = mutableSetOf("quiz_1")
+val CORRECT_QUIZ_IDS = hashSetOf("1")
+val INCORRECT_QUIZ_IDS = hashSetOf("1")
+val MARKED_QUIZ_IDS = hashSetOf("1")
 const val IS_MATCHED = true
 val passwordEncoder = BCryptPasswordEncoder()
 
@@ -64,9 +64,9 @@ fun createUserResponse(
     dailyTarget: Int = DAILY_TARGET,
     answerRate: Double = ANSWER_RATE,
     createdDate: LocalDateTime = CREATED_DATE,
-    correctQuizIds: Set<String> = CORRECT_QUIZ_IDS,
-    incorrectQuizIds: Set<String> = INCORRECT_QUIZ_IDS,
-    markedQuizIds: Set<String> = MARKED_QUIZ_IDS,
+    correctQuizIds: HashSet<String> = CORRECT_QUIZ_IDS,
+    incorrectQuizIds: HashSet<String> = INCORRECT_QUIZ_IDS,
+    markedQuizIds: HashSet<String> = MARKED_QUIZ_IDS,
 ): UserResponse =
     UserResponse(
         id = id,
@@ -117,9 +117,9 @@ fun createUser(
     allowPush: Boolean = ALLOW_PUSH,
     dailyTarget: Int = DAILY_TARGET,
     answerRate: Double = ANSWER_RATE,
-    correctQuizIds: MutableSet<String> = CORRECT_QUIZ_IDS.toMutableSet(),
-    incorrectQuizIds: MutableSet<String> = INCORRECT_QUIZ_IDS.toMutableSet(),
-    markedQuizIds: MutableSet<String> = MARKED_QUIZ_IDS.toMutableSet(),
+    correctQuizIds: HashSet<String> = CORRECT_QUIZ_IDS.toHashSet(),
+    incorrectQuizIds: HashSet<String> = INCORRECT_QUIZ_IDS.toHashSet(),
+    markedQuizIds: HashSet<String> = MARKED_QUIZ_IDS.toHashSet(),
     createdDate: LocalDateTime = CREATED_DATE
 ): User = User(
     id = id,

--- a/src/test/kotlin/com/quizit/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/quizit/user/service/UserServiceTest.kt
@@ -1,159 +1,247 @@
 package com.quizit.user.service
 
-import com.quizit.user.dto.response.UserResponse
+import com.quizit.user.exception.PermissionDeniedException
 import com.quizit.user.exception.UserNotFoundException
 import com.quizit.user.exception.UsernameAlreadyExistException
 import com.quizit.user.fixture.*
 import com.quizit.user.repository.UserRepository
-import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.equality.shouldBeEqualToComparingFields
 import io.kotest.matchers.equals.shouldNotBeEqual
 import io.kotest.matchers.shouldBe
-import io.mockk.*
-import kotlinx.coroutines.flow.flowOf
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.kotlin.test.expectError
+import reactor.test.StepVerifier
 
 class UserServiceTest : BehaviorSpec() {
     private val userRepository = mockk<UserRepository>()
 
-    private val userService: UserService = UserService(
+    private val userService = UserService(
         userRepository = userRepository,
         passwordEncoder = passwordEncoder
     )
 
+    override fun isolationMode(): IsolationMode = IsolationMode.InstancePerTest
+
     init {
         Given("유저가 존재하는 경우") {
-            val user = createUser().also {
-                coEvery { userRepository.findAll() } returns flowOf(it)
-                coEvery { userRepository.findAllOrderByCorrectQuizIdsSize() } returns flowOf(it)
-                coEvery { userRepository.findById(any()) } returns it
-                coEvery { userRepository.findByUsername(any()) } returns it
+            createUser().also {
+                every { userRepository.findAll() } returns Flux.just(it)
+                every { userRepository.findAllOrderByCorrectQuizIdsSize() } returns Flux.just(it)
+                every { userRepository.findById(any<String>()) } returns Mono.just(it)
+                every { userRepository.findByUsername(any()) } returns Mono.just(it)
+                every { userRepository.deleteById(any<String>()) } returns Mono.empty()
             }
 
-            coEvery { userRepository.deleteById(any()) } just runs
-
             When("유저 랭킹 조회를 시도하면") {
-                val userResponses = userService.getRanking()
+                val result = StepVerifier.create(userService.getRanking())
 
                 Then("모든 유저에 대한 랭킹이 조회된다.") {
-                    userResponses.collect { it shouldBeEqualToComparingFields UserResponse(user) }
+                    result.expectSubscription()
+                        .expectNext(createUserResponse())
+                        .verifyComplete()
                 }
             }
 
             When("식별자를 통해 유저 조회를 시도하면") {
-                val userResponse = userService.getUserById(user.id!!)
+                val result = StepVerifier.create(userService.getUserById(ID))
 
                 Then("식별자에 맞는 유저가 조회된다.") {
-                    userResponse shouldBeEqualToComparingFields UserResponse(user)
+                    result.expectSubscription()
+                        .expectNext(createUserResponse())
+                        .verifyComplete()
                 }
             }
 
             When("아이디를 통해 유저 조회를 시도하면") {
-                val userResponse = userService.getUserByUsername(user.username)
+                val result = StepVerifier.create(userService.getUserByUsername(USERNAME))
 
                 Then("아이디에 맞는 유저가 조회된다.") {
-                    userResponse shouldBeEqualToComparingFields UserResponse(user)
+                    result.expectSubscription()
+                        .expectNext(createUserResponse())
+                        .verifyComplete()
                 }
             }
 
             When("아이디를 통해 패스워드 일치 여부를 확인하면") {
-                val matchPasswordResponse = userService.matchPassword(user.username, createMatchPasswordRequest())
+                val result = StepVerifier.create(userService.matchPassword(USERNAME, createMatchPasswordRequest()))
 
                 Then("아이디에 맞는 유저의 패스워드 일치 여부가 확인된다.") {
-                    matchPasswordResponse.isMatched shouldBe true
+                    result.expectSubscription()
+                        .assertNext { it.isMatched shouldBe true }
+                        .verifyComplete()
                 }
             }
 
             When("프로필을 수정하면") {
-                val updateUserByIdRequest = createUpdateUserByIdRequest(nickname = "update").also {
-                    coEvery { userRepository.save(any()) } returns createUser(nickname = it.nickname)
-                }
-                val userResponse = userService.updateUserById(ID, createJwtAuthentication(), updateUserByIdRequest)
+                val updateUserByIdRequest = createUpdateUserByIdRequest(nickname = "updated_nickname")
+                    .also {
+                        every { userRepository.save(any()) } returns Mono.just(createUser(nickname = it.nickname))
+                    }
+                val result = StepVerifier.create(
+                    userService.updateUserById(ID, createJwtAuthentication(), updateUserByIdRequest)
+                )
 
                 Then("유저 정보가 변경된다.") {
-                    userResponse.nickname shouldNotBeEqual user.nickname
+                    result.expectSubscription()
+                        .assertNext { it.nickname shouldNotBeEqual NICKNAME }
+                        .verifyComplete()
                 }
             }
 
             When("패스워드를 수정하면") {
-                val changePasswordRequest = createChangePasswordRequest(newPassword = "update").also {
-                    coEvery { userRepository.save(any()) } returns createUser(
-                        password = passwordEncoder.encode(it.newPassword)
-                    )
-                }
+                val changePasswordRequest = createChangePasswordRequest(newPassword = "updated_password")
+                    .also {
+                        every { userRepository.save(any()) } returns Mono.just(
+                            createUser(password = passwordEncoder.encode(it.newPassword))
+                        )
+                    }
+
                 userService.changePassword(ID, createJwtAuthentication(), changePasswordRequest)
+                    .subscribe()
 
                 Then("패스워드가 변경된다.") {
-                    coVerify { userRepository.save(any()) }
+                    verify { userRepository.save(any()) }
                 }
             }
 
             When("회원 탈퇴를 하면") {
                 userService.deleteUserById(ID, createJwtAuthentication())
+                    .subscribe()
 
                 Then("유저가 삭제된다.") {
-                    coVerify { userRepository.deleteById(any()) }
+                    verify { userRepository.deleteById(any<String>()) }
                 }
             }
         }
 
         Given("유저가 존재하지 않는 경우") {
-            val user = createUser()
-
-            coEvery { userRepository.findById(any()) } returns null
-            coEvery { userRepository.findByUsername(any()) } returns null
+            createUser().apply {
+                every { userRepository.findById(any<String>()) } returns Mono.empty()
+                every { userRepository.findByUsername(any()) } returns Mono.empty()
+            }
 
             When("식별자를 통해 유저 조회를 시도하면") {
+                val result = StepVerifier.create(userService.getUserById(ID))
+
                 Then("예외가 발생한다.") {
-                    shouldThrow<UserNotFoundException> {
-                        userService.getUserById(user.id!!)
-                    }
+                    result.expectSubscription()
+                        .expectError<UserNotFoundException>()
+                        .verify()
                 }
             }
 
             When("아이디를 통해 유저 조회를 시도하면") {
+                val result = StepVerifier.create(userService.getUserByUsername(USERNAME))
+
                 Then("예외가 발생한다.") {
-                    shouldThrow<UserNotFoundException> {
-                        userService.getUserByUsername(user.username)
-                    }
+                    result.expectSubscription()
+                        .expectError<UserNotFoundException>()
+                        .verify()
                 }
             }
 
-            When("아이디를 통해 패스워드 일치 여부를 확인면") {
+            When("아이디를 통해 패스워드 일치 여부를 확인하면") {
+                val result = StepVerifier.create(userService.matchPassword(USERNAME, createMatchPasswordRequest()))
+
                 Then("예외가 발생한다.") {
-                    shouldThrow<UserNotFoundException> {
-                        userService.matchPassword(user.username, createMatchPasswordRequest())
-                    }
+                    result.expectSubscription()
+                        .expectError<UserNotFoundException>()
+                        .verify()
+                }
+            }
+
+            When("회원 탈퇴를 시도하면") {
+                val result = StepVerifier.create(userService.deleteUserById(ID, createJwtAuthentication()))
+
+                Then("예외가 발생한다.") {
+                    result.expectSubscription()
+                        .expectError<UserNotFoundException>()
+                        .verify()
                 }
             }
         }
 
         Given("해당 아이디를 가진 유저가 없는 경우") {
-            val user = createUser().also {
-                coEvery { userRepository.save(any()) } returns it
+            createUser().also {
+                every { userRepository.save(any()) } returns Mono.just(it)
+                every { userRepository.findByUsername(any()) } returns Mono.empty()
             }
 
-            coEvery { userRepository.findByUsername(any()) } returns null
-
             When("유저가 회원가입을 시도하면") {
-                val userResponse = userService.createUser(createCreateUserRequest())
+                val result = StepVerifier.create(userService.createUser(createCreateUserRequest()))
 
                 Then("유저가 생성된다.") {
-                    userResponse shouldBeEqualToComparingFields UserResponse(user)
+                    result.expectSubscription()
+                        .assertNext { it shouldBeEqualToComparingFields createUserResponse() }
+                        .verifyComplete()
                 }
             }
         }
 
         Given("해당 아이디를 가진 유저가 이미 존재하는 경우") {
             createUser().also {
-                coEvery { userRepository.findByUsername(any()) } returns it
+                every { userRepository.findByUsername(any()) } returns Mono.just(it)
             }
 
             When("유저가 회원가입을 시도하면") {
+                val result = StepVerifier.create(userService.createUser(createCreateUserRequest()))
+
                 Then("예외가 발생한다.") {
-                    shouldThrow<UsernameAlreadyExistException> {
-                        userService.createUser(createCreateUserRequest())
-                    }
+                    result.expectSubscription()
+                        .expectError<UsernameAlreadyExistException>()
+                        .verify()
+                }
+            }
+        }
+
+        Given("권한이 없는 경우") {
+            createUser().also {
+                every { userRepository.findById(any<String>()) } returns Mono.just(it)
+            }
+
+            When("프로필을 수정하면") {
+                val result =
+                    StepVerifier.create(
+                        userService.updateUserById(
+                            ID, createJwtAuthentication(id = "invalid_id"), createUpdateUserByIdRequest()
+                        )
+                    )
+
+                Then("예외가 발생한다.") {
+                    result.expectSubscription()
+                        .expectError<PermissionDeniedException>()
+                        .verify()
+                }
+            }
+
+            When("패스워드를 변경하면") {
+                val result = StepVerifier.create(
+                    userService.changePassword(
+                        ID, createJwtAuthentication(id = "invalid_id"), createChangePasswordRequest()
+                    )
+                )
+
+                Then("예외가 발생한다.") {
+                    result.expectSubscription()
+                        .expectError<PermissionDeniedException>()
+                        .verify()
+                }
+            }
+
+            When("회원 탈퇴를 시도하면") {
+                val result =
+                    StepVerifier.create(userService.deleteUserById(ID, createJwtAuthentication(id = "invalid_id")))
+
+                Then("예외가 발생한다.") {
+                    result.expectSubscription()
+                        .expectError<PermissionDeniedException>()
+                        .verify()
                 }
             }
         }

--- a/src/test/kotlin/com/quizit/user/util/TestUtil.kt
+++ b/src/test/kotlin/com/quizit/user/util/TestUtil.kt
@@ -1,5 +1,6 @@
 package com.quizit.user.util
 
+import com.quizit.user.domain.enum.Role
 import com.quizit.user.fixture.createJwtAuthentication
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
@@ -22,7 +23,7 @@ fun withMockUser() {
 
 fun withMockAdmin() {
     SecurityContextHolder.getContext().authentication =
-        createJwtAuthentication(authorities = listOf(SimpleGrantedAuthority("ADMIN")))
+        createJwtAuthentication(authorities = listOf(SimpleGrantedAuthority(Role.ADMIN.name)))
 }
 
 val errorResponseFields = listOf(

--- a/src/test/kotlin/com/quizit/user/util/TestUtil.kt
+++ b/src/test/kotlin/com/quizit/user/util/TestUtil.kt
@@ -9,10 +9,12 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 
 infix fun String.desc(description: String): FieldDescriptor =
-    fieldWithPath(this).description(description)
+    fieldWithPath(this)
+        .description(description)
 
 infix fun String.paramDesc(description: String): ParameterDescriptor =
-    parameterWithName(this).description(description)
+    parameterWithName(this)
+        .description(description)
 
 fun withMockUser() {
     SecurityContextHolder.getContext().authentication = createJwtAuthentication()


### PR DESCRIPTION
## 작업 내용

* **Spring WebFlux 환경에서 사용하던 Coroutine을 Reactive Streams 구현체인 Reactor로 대체**

## 코멘트

* 향후 추가될 Spring Reactive Stack 관련 기능들(OAuth, DynamoDB 등)에 대한 호환성 및 확장성을 위해 수행된 작업
* Kafka는 추후에 Reactor 기반 Reactive Kafka를 도입할 예정

## 관련 이슈

* **Close #38**