### PR TITLE
[#52] OAuth 연동 해지시 유저 삭제 구현

### DIFF
--- a/src/main/kotlin/com/quizit/user/adapter/consumer/AuthenticationConsumer.kt
+++ b/src/main/kotlin/com/quizit/user/adapter/consumer/AuthenticationConsumer.kt
@@ -1,0 +1,39 @@
+package com.quizit.user.adapter.consumer
+
+import com.quizit.user.adapter.producer.UserProducer
+import com.quizit.user.dto.event.DeleteUserEvent
+import com.quizit.user.dto.event.RevokeOAuthEvent
+import com.quizit.user.global.annotation.Consumer
+import com.quizit.user.repository.UserRepository
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.springframework.boot.context.event.ApplicationStartedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.kafka.core.reactive.ReactiveKafkaConsumerTemplate
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
+
+@Consumer
+class AuthenticationConsumer(
+    private val revokeOAuthConsumer: ReactiveKafkaConsumerTemplate<String, RevokeOAuthEvent>,
+    private val userProducer: UserProducer,
+    private val userRepository: UserRepository
+) {
+    @EventListener(ApplicationStartedEvent::class)
+    fun revokeOAuth(): Flux<ConsumerRecord<String, RevokeOAuthEvent>> =
+        revokeOAuthConsumer.receiveAutoAck()
+            .doOnNext { message ->
+                with(message.value()) {
+                    userRepository.findByEmailAndProvider(email, provider)
+                        .flatMap {
+                            Mono.zip(
+                                userRepository.deleteById(it.id!!)
+                                    .subscribeOn(Schedulers.boundedElastic()),
+                                userProducer.deleteUser(DeleteUserEvent(it.id!!))
+                                    .subscribeOn(Schedulers.boundedElastic())
+                            )
+                        }
+                        .subscribe()
+                }
+            }
+}

--- a/src/main/kotlin/com/quizit/user/adapter/consumer/QuizConsumer.kt
+++ b/src/main/kotlin/com/quizit/user/adapter/consumer/QuizConsumer.kt
@@ -12,7 +12,7 @@ import org.springframework.kafka.core.reactive.ReactiveKafkaConsumerTemplate
 import reactor.core.publisher.Flux
 
 @Consumer
-class UserConsumer(
+class QuizConsumer(
     private val deleteQuizConsumer: ReactiveKafkaConsumerTemplate<String, DeleteQuizEvent>,
     private val markQuizConsumer: ReactiveKafkaConsumerTemplate<String, MarkQuizEvent>,
     private val checkAnswerConsumer: ReactiveKafkaConsumerTemplate<String, CheckAnswerEvent>,

--- a/src/main/kotlin/com/quizit/user/dto/event/RevokeOAuthEvent.kt
+++ b/src/main/kotlin/com/quizit/user/dto/event/RevokeOAuthEvent.kt
@@ -1,0 +1,8 @@
+package com.quizit.user.dto.event
+
+import com.quizit.user.domain.enum.Provider
+
+data class RevokeOAuthEvent(
+    val email: String,
+    val provider: Provider
+)

--- a/src/main/kotlin/com/quizit/user/global/config/KafkaConfiguration.kt
+++ b/src/main/kotlin/com/quizit/user/global/config/KafkaConfiguration.kt
@@ -3,6 +3,7 @@ package com.quizit.user.global.config
 import com.quizit.user.dto.event.CheckAnswerEvent
 import com.quizit.user.dto.event.DeleteQuizEvent
 import com.quizit.user.dto.event.MarkQuizEvent
+import com.quizit.user.dto.event.RevokeOAuthEvent
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -29,6 +30,10 @@ class ProducerConfiguration(
 class ConsumerConfiguration(
     private val properties: KafkaProperties
 ) {
+    @Bean
+    fun revokeOAuthConsumer(): ReactiveKafkaConsumerTemplate<String, RevokeOAuthEvent> =
+        ReactiveKafkaConsumerTemplate(createReceiverOptions("revoke-oauth"))
+
     @Bean
     fun deleteQuizConsumer(): ReactiveKafkaConsumerTemplate<String, DeleteQuizEvent> =
         ReactiveKafkaConsumerTemplate(createReceiverOptions("delete-quiz"))


### PR DESCRIPTION
## 작업 내용

* **OAuth 연동 해지 이벤트를 구독하는 consumer 구현**

## 관련 이슈

* **Close #52**